### PR TITLE
Bash completion

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -7,6 +7,9 @@ do
 	go $i ./cmd/...
 done
 }
+do-gh-get-authtoken () {
+  ~/go/bin/yq r ~/.config/gh/hosts.yml '"github.com".oauth_token'
+}
 
 alias be='bundle exec'
 # alias k=kubectl

--- a/.bash_aliases
+++ b/.bash_aliases
@@ -79,5 +79,6 @@ alias hephy="git clone https://github.com/kingdonb/gitops-hephy.git -b kingdonb"
 # alias remem="git config credential.helper store"
 alias kubec="mkdir ~/.kube; scp yebyen@nerdland.info:kubeconfig~ ~/.kube/config"
 alias kingdonb="kubectl config set-context --current --namespace=kingdonb"
-alias ahmetb="go get -d $KUBECTX; pushd $GOPATH/src/$KUBECTX; go-get-binaries; popd"
+alias ahmetb="go get -d $KUBECTX; pushd ~/go/src/$KUBECTX; go-get-binaries; popd"
+alias ghtoken='export GITHUB_TOKEN=`do-gh-get-authtoken`'
 # alias home="hephy; remem; ascp; kubec; apks; get-go.sh; ahmetb"

--- a/.bash_profile
+++ b/.bash_profile
@@ -10,6 +10,7 @@ fi
 # export KUBECONFIG="$HOME/.kube/config:$HOME/Downloads/hephynator--gullible-relationship-kubeconfig.yaml"
 
 [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
+[[ -r "/usr/local/etc/bash_completion.d/git-completion.bash" ]] && . "/usr/local/etc/bash_completion.d/git-completion.bash"
 
 [[ -s "$HOME/.profile" ]] && source "$HOME/.profile" # Load the default .profile
 
@@ -21,6 +22,8 @@ fi
 
 . <(flux completion bash)
 . <(gh completion bash)
+. <(helm completion bash)
 
+. <(jx completion bash)
 . <(kubectl completion bash)
 . <(loft completion bash)

--- a/.bash_profile
+++ b/.bash_profile
@@ -21,3 +21,4 @@ fi
 
 . <(kubectl completion bash)
 . <(flux completion bash)
+. <(loft completion bash)

--- a/.bash_profile
+++ b/.bash_profile
@@ -19,6 +19,8 @@ fi
 
 . $HOME/.asdf/completions/asdf.bash
 
-. <(kubectl completion bash)
 . <(flux completion bash)
+. <(gh completion bash)
+
+. <(kubectl completion bash)
 . <(loft completion bash)

--- a/.bash_profile
+++ b/.bash_profile
@@ -19,4 +19,5 @@ fi
 
 . $HOME/.asdf/completions/asdf.bash
 
+. <(kubectl completion bash)
 . <(flux completion bash)


### PR DESCRIPTION
Updates to bash completion

Harvesting Github auth tokens in a different way (#2)

Fixup `ahmetb` alias for installing kubectx, kubens... let's just standardize on a GO_PATH root of `~/go`, since `$GO_PATH` may not be singular (eg. right now, ours isn't).